### PR TITLE
Some fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@
         <dependency>
             <groupId>com.sk89q</groupId>
             <artifactId>commandhelper</artifactId>
-            <version>3.3.1-SNAPSHOT</version>
+            <version>3.3.2-SNAPSHOT</version>
             <type>jar</type>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>me.entityreborn</groupId>
     <artifactId>chvirtualchests</artifactId>
-    <version>1.0.3-SNAPSHOT</version>
+    <version>1.0.4</version>
     <name>CHVirtualChests</name>
     <description>CHVirtualChests is an extension to CommandHelper which exposes a virtual chest system.</description>
     

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>me.entityreborn</groupId>
     <artifactId>chvirtualchests</artifactId>
-    <version>1.0.4</version>
+    <version>1.0.5</version>
     <name>CHVirtualChests</name>
     <description>CHVirtualChests is an extension to CommandHelper which exposes a virtual chest system.</description>
     

--- a/src/main/java/com/entityreborn/chvirtualchests/LifeCycle.java
+++ b/src/main/java/com/entityreborn/chvirtualchests/LifeCycle.java
@@ -51,6 +51,6 @@ public class LifeCycle extends AbstractExtension {
     }
 
     public Version getVersion() {
-        return new SimpleVersion(1,0,4);
+        return new SimpleVersion(1,0,5);
     }
 }

--- a/src/main/java/com/entityreborn/chvirtualchests/LifeCycle.java
+++ b/src/main/java/com/entityreborn/chvirtualchests/LifeCycle.java
@@ -24,6 +24,8 @@
 
 package com.entityreborn.chvirtualchests;
 
+import com.entityreborn.chvirtualchests.events.Events;
+import com.entityreborn.chvirtualchests.functions.Player;
 import com.laytonsmith.PureUtilities.SimpleVersion;
 import com.laytonsmith.PureUtilities.Version;
 import com.laytonsmith.core.extensions.AbstractExtension;
@@ -37,11 +39,14 @@ import com.laytonsmith.core.extensions.MSExtension;
 public class LifeCycle extends AbstractExtension {
     @Override
     public void onStartup() {
+        Events.register();
         System.out.println("CHVC " + getVersion() + " loaded.");
     }
     
     @Override
     public void onShutdown() {
+        Player.closeVirtualChests();
+        Events.unregister();
         System.out.println("CHVC " + getVersion() + " unloaded.");
     }
 

--- a/src/main/java/com/entityreborn/chvirtualchests/LifeCycle.java
+++ b/src/main/java/com/entityreborn/chvirtualchests/LifeCycle.java
@@ -51,6 +51,6 @@ public class LifeCycle extends AbstractExtension {
     }
 
     public Version getVersion() {
-        return new SimpleVersion(1,0,3);
+        return new SimpleVersion(1,0,4);
     }
 }

--- a/src/main/java/com/entityreborn/chvirtualchests/VirtualChests.java
+++ b/src/main/java/com/entityreborn/chvirtualchests/VirtualChests.java
@@ -32,8 +32,8 @@ import com.laytonsmith.core.constructs.CArray;
 import com.laytonsmith.core.constructs.CInt;
 import com.laytonsmith.core.constructs.Construct;
 import com.laytonsmith.core.constructs.Target;
+import com.laytonsmith.core.exceptions.CRE.CREFormatException;
 import com.laytonsmith.core.exceptions.ConfigRuntimeException;
-import com.laytonsmith.core.functions.Exceptions;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -129,7 +129,7 @@ public class VirtualChests {
         if (array.containsKey("id")) {
             id = array.get("id", t).val();
         } else {
-            throw new ConfigRuntimeException("Expecting item with key 'id' in array", Exceptions.ExceptionType.FormatException, t);
+            throw new CREFormatException("Expecting item with key 'id' in array", t);
         }
 
         if (array.containsKey("size")) {

--- a/src/main/java/com/entityreborn/chvirtualchests/VirtualChests.java
+++ b/src/main/java/com/entityreborn/chvirtualchests/VirtualChests.java
@@ -101,38 +101,38 @@ public class VirtualChests {
         return inv;
     }
 
-    public static CArray toCArray(MCInventory inv) {
-        CArray items = CArray.GetAssociativeArray(Target.UNKNOWN);
+    public static CArray toCArray(MCInventory inv, Target t) {
+        CArray items = CArray.GetAssociativeArray(t);
 
         for (int i = 0; i < inv.getSize(); i++) {
-            Construct c = ObjectGenerator.GetGenerator().item(inv.getItem(i), Target.UNKNOWN);
-            items.set(i, c, Target.UNKNOWN);
+            Construct c = ObjectGenerator.GetGenerator().item(inv.getItem(i), t);
+            items.set(i, c, t);
         }
 
         items.set("id", getID(inv));
-        items.set("size", String.valueOf(inv.getSize()));
+        items.set("size", new CInt(inv.getSize(), t), t);
         items.set("title", inv.getTitle());
 
         return items;
     }
 
-    public static MCInventory fromCArray(Target t, CArray array) {
+    public static MCInventory fromCArray(CArray array, Target t) {
         String id = "";
         String title = "Virtual Chest";
         int size = 54;
 
         if (array.containsKey("id")) {
-            id = array.get("id", t).getValue();
+            id = array.get("id", t).val();
         } else {
-            throw new ConfigRuntimeException("Expecting item with key 'id' in arg 2 array", Exceptions.ExceptionType.FormatException, t);
+            throw new ConfigRuntimeException("Expecting item with key 'id' in array", Exceptions.ExceptionType.FormatException, t);
         }
 
-        if (array.containsKey("size") && array.get("size", t) instanceof CInt) {
-            size = (int) ((CInt) array.get("size", t)).getInt();
+        if (array.containsKey("size")) {
+            size = Static.getInt32(array.get("size", t), t);
         }
 
         if (array.containsKey("title")) {
-            title = array.get("title", t).getValue();
+            title = array.get("title", t).val();
         }
 
         MCInventory inv = VirtualChests.create(id, size, title);

--- a/src/main/java/com/entityreborn/chvirtualchests/VirtualChests.java
+++ b/src/main/java/com/entityreborn/chvirtualchests/VirtualChests.java
@@ -80,6 +80,9 @@ public class VirtualChests {
 
     public static MCInventory setContents(MCInventory inv, CArray items, Target t) {
         for (String key : items.stringKeySet()) {
+            if(key.equals("id") || key.equals("size") || key.equals("title")) {
+                continue;
+            }
             try {
                 int index = Integer.parseInt(key);
 
@@ -91,10 +94,12 @@ public class VirtualChests {
                         inv.setItem(index, is);
                     }
                 } else {
-                    ConfigRuntimeException.DoWarning("Out of range value (" + index + ") found in array passed to set_virtualchest(), so ignoring.");
+                    ConfigRuntimeException.DoWarning("Out of range value (" + index + ") found in array passed to"
+                            + " virtualchest, so ignoring.");
                 }
             } catch (NumberFormatException e) {
-                ConfigRuntimeException.DoWarning("Expecting integer value for key in array passed to set_pinv(), but \"" + key + "\" was found. Ignoring.");
+                ConfigRuntimeException.DoWarning("Expecting integer value for key in array passed to virtualchest, but"
+                        + " \"" + key + "\" was found. Ignoring.");
             }
         }
 

--- a/src/main/java/com/entityreborn/chvirtualchests/functions/General.java
+++ b/src/main/java/com/entityreborn/chvirtualchests/functions/General.java
@@ -43,9 +43,11 @@ import com.laytonsmith.core.constructs.Construct;
 import com.laytonsmith.core.constructs.Target;
 import com.laytonsmith.core.environments.CommandHelperEnvironment;
 import com.laytonsmith.core.environments.Environment;
+import com.laytonsmith.core.exceptions.CRE.CRECastException;
+import com.laytonsmith.core.exceptions.CRE.CREFormatException;
+import com.laytonsmith.core.exceptions.CRE.CREThrowable;
 import com.laytonsmith.core.exceptions.ConfigRuntimeException;
 import com.laytonsmith.core.functions.AbstractFunction;
-import com.laytonsmith.core.functions.Exceptions;
 import java.util.Map;
 
 /**
@@ -57,8 +59,8 @@ public class General {
     @api(environments = {CommandHelperEnvironment.class})
     public static class get_virtualchest extends AbstractFunction {
 
-        public Exceptions.ExceptionType[] thrown() {
-            return new Exceptions.ExceptionType[]{Exceptions.ExceptionType.FormatException};
+        public Class<? extends CREThrowable>[] thrown() {
+            return new Class[]{CREFormatException.class};
         }
 
         public boolean isRestricted() {
@@ -73,7 +75,7 @@ public class General {
             String id = args[0].getValue();
 
             if (id.isEmpty() || args[0] instanceof CNull) {
-                throw new ConfigRuntimeException("invalid id. Use either a string or integer.", Exceptions.ExceptionType.FormatException, t);
+                throw new CREFormatException("invalid id. Use either a string or integer.", t);
             }
 
             MCInventory inv = VirtualChests.get(id);
@@ -108,7 +110,7 @@ public class General {
     @api(environments = {CommandHelperEnvironment.class})
     public static class close_virtualchest extends AbstractFunction {
 
-        public Exceptions.ExceptionType[] thrown() {
+        public Class<? extends CREThrowable>[] thrown() {
             return null;
         }
 
@@ -124,7 +126,7 @@ public class General {
             String id = args[0].getValue();
 
             if (id.isEmpty() || args[0] instanceof CNull) {
-                throw new ConfigRuntimeException("invalid id. Use either a string or integer.", Exceptions.ExceptionType.FormatException, t);
+                throw new CREFormatException("invalid id. Use either a string or integer.", t);
             }
 
             MCInventory inv = VirtualChests.get(id);
@@ -158,8 +160,8 @@ public class General {
     @api(environments = {CommandHelperEnvironment.class})
     public static class create_virtualchest extends AbstractFunction {
 
-        public Exceptions.ExceptionType[] thrown() {
-            return new Exceptions.ExceptionType[]{Exceptions.ExceptionType.FormatException};
+        public Class<? extends CREThrowable>[] thrown() {
+            return new Class[]{CREFormatException.class};
         }
 
         public boolean isRestricted() {
@@ -179,9 +181,8 @@ public class General {
                 items = (CArray) args[0];
                 inv = VirtualChests.fromCArray(items, t);
             } else {
-                throw new ConfigRuntimeException("bad arguments. Expecting item "
-                        + "array including 'id', and optionally 'size' and 'title'.",
-                        Exceptions.ExceptionType.FormatException, t);
+                throw new CREFormatException("bad arguments. Expecting item "
+                        + "array including 'id', and optionally 'size' and 'title'.", t);
             }
 
             VirtualChests.set(VirtualChests.getID(inv), inv);
@@ -213,8 +214,8 @@ public class General {
     @api(environments = {CommandHelperEnvironment.class})
     public static class set_virtualchest extends AbstractFunction {
 
-        public Exceptions.ExceptionType[] thrown() {
-            return new Exceptions.ExceptionType[]{Exceptions.ExceptionType.FormatException};
+        public Class<? extends CREThrowable>[] thrown() {
+            return new Class[]{CREFormatException.class};
         }
 
         public boolean isRestricted() {
@@ -233,7 +234,7 @@ public class General {
             CArray items;
             if (args.length == 2) {
                 if (args[0].val().isEmpty() || args[0] instanceof CNull) {
-                    throw new ConfigRuntimeException("invalid id. Use either a string or integer.", Exceptions.ExceptionType.FormatException, t);
+                    throw new CREFormatException("invalid id. Use either a string or integer.", t);
                 }
 
                 id = args[0].val();
@@ -250,7 +251,7 @@ public class General {
 
                     return CVoid.VOID;
                 } else {
-                    throw new ConfigRuntimeException("Expecting an array or null as argument 2", Exceptions.ExceptionType.CastException, t);
+                    throw new CRECastException("Expecting an array or null as argument 2", t);
                 }
             } else {
                 if (args[0] instanceof CArray) {
@@ -259,7 +260,7 @@ public class General {
                     id = VirtualChests.getID(inv);
                     VirtualChests.set(id, inv);
                 } else {
-                    throw new ConfigRuntimeException("Expecting an array or null as argument 1", Exceptions.ExceptionType.CastException, t);
+                    throw new CRECastException("Expecting an array or null as argument 1", t);
                 }
             }
 
@@ -291,8 +292,8 @@ public class General {
     @api(environments = {CommandHelperEnvironment.class})
     public static class addto_virtualchest extends AbstractFunction {
 
-        public Exceptions.ExceptionType[] thrown() {
-            return new Exceptions.ExceptionType[]{Exceptions.ExceptionType.FormatException};
+        public Class<? extends CREThrowable>[] thrown() {
+            return new Class[]{CREFormatException.class};
         }
 
         public boolean isRestricted() {
@@ -310,7 +311,7 @@ public class General {
             Construct m = null;
 
             if (args[0].val().isEmpty() || args[0] instanceof CNull) {
-                throw new ConfigRuntimeException("invalid id. Use either a string or integer.", Exceptions.ExceptionType.FormatException, t);
+                throw new CREFormatException("invalid id. Use either a string or integer.", t);
             }
 
             id = args[0].val();
@@ -373,8 +374,8 @@ public class General {
     @api(environments = {CommandHelperEnvironment.class})
     public static class takefrom_virtualchest extends AbstractFunction {
 
-        public Exceptions.ExceptionType[] thrown() {
-            return new Exceptions.ExceptionType[]{Exceptions.ExceptionType.FormatException};
+        public Class<? extends CREThrowable>[] thrown() {
+            return new Class[]{CREFormatException.class};
         }
 
         public boolean isRestricted() {
@@ -391,7 +392,7 @@ public class General {
             MCItemStack is;
 
             if (args[0].val().isEmpty() || args[0] instanceof CNull) {
-                throw new ConfigRuntimeException("invalid id. Use either a string or integer.", Exceptions.ExceptionType.FormatException, t);
+                throw new CREFormatException("invalid id. Use either a string or integer.", t);
             }
 
             id = args[0].val();
@@ -454,8 +455,8 @@ public class General {
     @api(environments = {CommandHelperEnvironment.class})
     public static class update_virtualchest extends AbstractFunction {
 
-        public Exceptions.ExceptionType[] thrown() {
-            return new Exceptions.ExceptionType[]{Exceptions.ExceptionType.FormatException};
+        public Class<? extends CREThrowable>[] thrown() {
+            return new Class[]{CREFormatException.class};
         }
 
         public boolean isRestricted() {
@@ -472,7 +473,7 @@ public class General {
             CArray items;
             if (args.length == 2) {
                 if (args[0].val().isEmpty() || args[0] instanceof CNull) {
-                    throw new ConfigRuntimeException("invalid id. Use either a string or integer.", Exceptions.ExceptionType.FormatException, t);
+                    throw new CREFormatException("invalid id. Use either a string or integer.", t);
                 }
 
                 id = args[0].val();
@@ -480,19 +481,19 @@ public class General {
                 if (args[1] instanceof CArray) {
                     items = (CArray) args[1];
                 } else {
-                    throw new ConfigRuntimeException("Expecting an array or null as argument 2", Exceptions.ExceptionType.CastException, t);
+                    throw new CRECastException("Expecting an array or null as argument 2", t);
                 }
             } else {
                 if (args[0] instanceof CArray) {
                     items = (CArray) args[0];
 
                     if (!items.containsKey("id")) {
-                        throw new ConfigRuntimeException("No id specified in array. Use either a string or integer.", Exceptions.ExceptionType.FormatException, t);
+                        throw new CREFormatException("No id specified in array. Use either a string or integer.", t);
                     }
 
                     id = items.get("id", t).val();
                 } else {
-                    throw new ConfigRuntimeException("Expecting an array or null as argument 2", Exceptions.ExceptionType.CastException, t);
+                    throw new CRECastException("Expecting an array or null as argument 2", t);
                 }
             }
 
@@ -531,8 +532,8 @@ public class General {
     @api(environments = {CommandHelperEnvironment.class})
     public static class del_virtualchest extends AbstractFunction {
 
-        public Exceptions.ExceptionType[] thrown() {
-            return new Exceptions.ExceptionType[]{Exceptions.ExceptionType.FormatException};
+        public Class<? extends CREThrowable>[] thrown() {
+            return new Class[]{CREFormatException.class};
         }
 
         public boolean isRestricted() {
@@ -547,7 +548,7 @@ public class General {
             String id = args[0].getValue();
 
             if (id.isEmpty() || args[0] instanceof CNull) {
-                throw new ConfigRuntimeException("invalid id. Use either a string or integer.", Exceptions.ExceptionType.FormatException, t);
+                throw new CREFormatException("invalid id. Use either a string or integer.", t);
             }
 
             if (VirtualChests.get(id) != null) {
@@ -581,7 +582,7 @@ public class General {
     @api(environments = {CommandHelperEnvironment.class})
     public static class all_virtualchests extends AbstractFunction {
 
-        public Exceptions.ExceptionType[] thrown() {
+        public Class<? extends CREThrowable>[] thrown() {
             return null;
         }
 
@@ -597,7 +598,7 @@ public class General {
             CArray arr = new CArray(t);
 
             for (String key : VirtualChests.getAll()) {
-                arr.push(new CString(key, t));
+                arr.push(new CString(key, t), t);
             }
 
             return arr;
@@ -623,7 +624,7 @@ public class General {
     @api(environments = {CommandHelperEnvironment.class})
     public static class clear_virtualchest extends AbstractFunction {
 
-        public Exceptions.ExceptionType[] thrown() {
+        public Class<? extends CREThrowable>[] thrown() {
             return null;
         }
 
@@ -639,7 +640,7 @@ public class General {
             String id = args[0].getValue();
 
             if (id.isEmpty() || args[0] instanceof CNull) {
-                throw new ConfigRuntimeException("invalid id. Use either a string or integer.", Exceptions.ExceptionType.FormatException, t);
+                throw new CREFormatException("invalid id. Use either a string or integer.", t);
             }
 
             MCInventory inv = VirtualChests.get(id);
@@ -652,14 +653,12 @@ public class General {
                     if (i >= 0 && i < inv.getSize()) {
                         inv.clear(i);
                     } else {
-                        throw new ConfigRuntimeException(
-                                "invalid slot. Use an integer 0 or above and less than "
-                                + inv.getSize(), Exceptions.ExceptionType.FormatException, t);
+                        throw new CREFormatException("invalid slot. Use an integer 0 or above and less than "
+                                + inv.getSize(), t);
                     }
                 } else {
-                    throw new ConfigRuntimeException(
-                            "invalid slot. Use an integer 0 or above and less than "
-                            + inv.getSize(), Exceptions.ExceptionType.FormatException, t);
+                    throw new CREFormatException("invalid slot. Use an integer 0 or above and less than "
+                            + inv.getSize(), t);
                 }
             } else {
                 inv.clear();

--- a/src/main/java/com/entityreborn/chvirtualchests/functions/General.java
+++ b/src/main/java/com/entityreborn/chvirtualchests/functions/General.java
@@ -143,12 +143,11 @@ public class General {
         }
 
         public Integer[] numArgs() {
-            return new Integer[]{1, 2};
+            return new Integer[]{1};
         }
 
         public String docs() {
-            return "void {[player,] id} Closes the specified virtualchest on either the"
-                    + " specified player, or all players viewing that virtualchest.";
+            return "void {id} Closes the specified virtualchest on all players viewing that virtualchest.";
         }
 
         public CHVersion since() {
@@ -195,14 +194,15 @@ public class General {
         }
 
         public Integer[] numArgs() {
-            return new Integer[]{1, 2};
+            return new Integer[]{1};
         }
 
         public String docs() {
-            return "void {id[, options]} Creates a cached virtual chest associated with a given id. The id is case "
-                    + "insensitive. options is expected to be an array which could "
-                    + "contain the optional following keys: size (int), title (string), items "
-                    + "(indexed list of items). Defaults to 54, \"Virtual Chest\" and empty, respectively.";
+            return "void {chestdata} Creates a cached virtual chest associated with a given id."
+                    + " The chestdata is expected to be an array with the key \"id\" (string) and "
+                    + " optionally \"size\" (int) and \"title\" (string). The array may also contain"
+                    + " item arrays under integer keys representing the slots in the virtual chest."
+                    + " Size defaults to 54, and title defaults to \"Virtual Chest\".";
         }
 
         public CHVersion since() {
@@ -275,7 +275,7 @@ public class General {
         }
 
         public String docs() {
-            return "void {id, array} Sets a cached virtual chest associated with a given id. The "
+            return "void {[id,] array} Sets a cached virtual chest associated with a given id. The "
                     + "array must be an indexed associative array, whose indexes correspond with "
                     + "slot locations and values are synonymous with those of set_pinv(). "
                     + "The array can be incomplete, indexes not mentioned will be "
@@ -499,7 +499,7 @@ public class General {
             inv = VirtualChests.get(id);
 
             if (inv != null) {
-            VirtualChests.setContents(inv, items, t);
+                VirtualChests.setContents(inv, items, t);
             }
 
             return CVoid.VOID;
@@ -514,7 +514,7 @@ public class General {
         }
 
         public String docs() {
-            return "void {id, array} Updates a cached virtual chest associated with a given id. The "
+            return "void {[id,] array} Updates a cached virtual chest associated with a given id. The "
                     + "array must be an indexed associative array, whose indexes correspond with "
                     + "slot locations and values are synonymous with those of set_pinv(). "
                     + "The array can be incomplete, indexes not mentioned will be "

--- a/src/main/java/com/entityreborn/chvirtualchests/functions/Player.java
+++ b/src/main/java/com/entityreborn/chvirtualchests/functions/Player.java
@@ -28,7 +28,6 @@ import com.laytonsmith.abstraction.MCHumanEntity;
 import com.laytonsmith.abstraction.MCInventory;
 import com.laytonsmith.abstraction.MCPlayer;
 import com.laytonsmith.annotations.api;
-import com.laytonsmith.annotations.shutdown;
 import com.laytonsmith.core.CHVersion;
 import com.laytonsmith.core.Static;
 import com.laytonsmith.core.constructs.CArray;
@@ -48,8 +47,7 @@ import com.laytonsmith.core.functions.Exceptions;
  */
 public class Player {
 
-    @shutdown
-    public static void onShutdown() {
+    public static void closeVirtualChests() {
         for (String id : VirtualChests.getAll()) {
             for (MCHumanEntity p : VirtualChests.get(id).getViewers()) {
                 if (p != null) {

--- a/src/main/java/com/entityreborn/chvirtualchests/functions/Player.java
+++ b/src/main/java/com/entityreborn/chvirtualchests/functions/Player.java
@@ -37,9 +37,11 @@ import com.laytonsmith.core.constructs.Construct;
 import com.laytonsmith.core.constructs.Target;
 import com.laytonsmith.core.environments.CommandHelperEnvironment;
 import com.laytonsmith.core.environments.Environment;
+import com.laytonsmith.core.exceptions.CRE.CREFormatException;
+import com.laytonsmith.core.exceptions.CRE.CRENullPointerException;
+import com.laytonsmith.core.exceptions.CRE.CREThrowable;
 import com.laytonsmith.core.exceptions.ConfigRuntimeException;
 import com.laytonsmith.core.functions.AbstractFunction;
-import com.laytonsmith.core.functions.Exceptions;
 
 /**
  *
@@ -64,8 +66,8 @@ public class Player {
     @api(environments = {CommandHelperEnvironment.class})
     public static class popen_virtualchest extends AbstractFunction {
 
-        public Exceptions.ExceptionType[] thrown() {
-            return new Exceptions.ExceptionType[]{Exceptions.ExceptionType.FormatException};
+        public Class<? extends CREThrowable>[] thrown() {
+            return new Class[]{CREFormatException.class};
         }
 
         public boolean isRestricted() {
@@ -85,14 +87,14 @@ public class Player {
                 id = args[1].getValue();
 
                 if (id.isEmpty() || args[1] instanceof CNull) {
-                    throw new ConfigRuntimeException("invalid id. Use either a string or integer.", Exceptions.ExceptionType.FormatException, t);
+                    throw new CREFormatException("invalid id. Use either a string or integer.", t);
                 }
             } else {
                 p = environment.getEnv(CommandHelperEnvironment.class).GetPlayer();
                 id = args[0].getValue();
 
                 if (id.isEmpty() || args[0] instanceof CNull) {
-                    throw new ConfigRuntimeException("invalid id. Use either a string or integer.", Exceptions.ExceptionType.FormatException, t);
+                    throw new CREFormatException("invalid id. Use either a string or integer.", t);
                 }
             }
 
@@ -128,7 +130,7 @@ public class Player {
     @api(environments = {CommandHelperEnvironment.class})
     public static class pget_virtualchest extends AbstractFunction {
 
-        public Exceptions.ExceptionType[] thrown() {
+        public Class<? extends CREThrowable>[] thrown() {
             return null;
         }
 
@@ -182,9 +184,9 @@ public class Player {
     @api(environments = {CommandHelperEnvironment.class})
     public static class pviewing_virtualchest extends AbstractFunction {
 
-        public Exceptions.ExceptionType[] thrown() {
-            return new Exceptions.ExceptionType[]{Exceptions.ExceptionType.FormatException,
-                Exceptions.ExceptionType.NullPointerException};
+        public Class<? extends CREThrowable>[] thrown() {
+            return new Class[]{CREFormatException.class,
+                CRENullPointerException.class};
         }
 
         public boolean isRestricted() {
@@ -200,17 +202,17 @@ public class Player {
             String id = args[0].getValue();
 
             if (id.isEmpty() || args[0] instanceof CNull) {
-                throw new ConfigRuntimeException("invalid id. Use either a string or integer.", Exceptions.ExceptionType.FormatException, t);
+                throw new CREFormatException("invalid id. Use either a string or integer.", t);
             }
 
             MCInventory inv = VirtualChests.get(id);
 
             if (inv == null) {
-                throw new ConfigRuntimeException("unknown chest id. Please consult all_virtualchests().", Exceptions.ExceptionType.NullPointerException, t);
+                throw new CRENullPointerException("unknown chest id. Please consult all_virtualchests().", t);
             }
 
             for (MCHumanEntity p : inv.getViewers()) {
-                arr.push(new CString(p.getName(), t));
+                arr.push(new CString(p.getName(), t), t);
             }
 
             return arr;

--- a/src/main/resources/documentation/Functions.md
+++ b/src/main/resources/documentation/Functions.md
@@ -100,7 +100,7 @@ This will also close the virtualchest for any viewers.
 
 ---
 
-<a id="setvc"></a>`set_virtualchest(`[`@id`][id]`,` [`@itemarray`][itemarray]`)` - *Set a chest whose id is `@id` to contain the items from `@itemarray`.*
+<a id="setvc"></a>`set_virtualchest(`[`@id`][id]`,` [`@chestdata`][chestdata]`)` - *Set a chest whose id is `@id` to contain the items from `@itemarray`.*
 
 The original contents are replaced entirely.
 


### PR DESCRIPTION
This attempts to not change any existing behavior, but instead fix several issues. For example, I think it might be good to change the behavior of set_virtualchest, but that's not within the scope of this PR.

- Size wasn't getting saved/retrieved to/from CArrays properly, so using chestdata to recreate a chest defaulted it to 54.

- TriggerExternal/@event is deprecated, so it needed its own event handlers. 

- Using chestdata keys when setting the contents would constantly post warnings under certain settings. It also threw 3 exceptions in a non-exceptional case, which is slower than just checking.

- Some docs and numargs weren't updated.

- set_virtualchest with null arg wasn't checking the correct arg. 

- A few functions were running methods redundantly.

- A setter (update_virtualchest) was sometimes returning cnull, sometimes cvoid. For now I set it to only return cvoid, but maybe it should throw an exception when the virtualchest doesn't exist. This is inconsistent with other functions, so maybe all functions should throw exceptions in those cases.

- Some errors were reporting function names (and/or args) that may or may not have called the method.
