### PR TITLE
Support multiple inventory types using key "type"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,15 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.3</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>buildnumber-maven-plugin</artifactId>
                 

--- a/src/main/java/com/entityreborn/chvirtualchests/functions/General.java
+++ b/src/main/java/com/entityreborn/chvirtualchests/functions/General.java
@@ -316,7 +316,8 @@ public class General {
 
             id = args[0].val();
 
-            if (VirtualChests.get(id) == null) {
+            inv = VirtualChests.get(id);
+            if (inv == null) {
                 return CNull.NULL;
             }
 
@@ -334,8 +335,6 @@ public class General {
             }
 
             is.setItemMeta(meta);
-
-            inv = VirtualChests.get(id);
 
             Map<Integer, MCItemStack> h = inv.addItem(is);
 
@@ -397,13 +396,12 @@ public class General {
 
             id = args[0].val();
 
-            if (VirtualChests.get(id) == null) {
+            inv = VirtualChests.get(id);
+            if (inv == null) {
                 return CNull.NULL;
             }
 
             is = Static.ParseItemNotation(this.getName(), args[1].val(), Static.getInt32(args[2], t), t);
-
-            inv = VirtualChests.get(id);
 
             int total = is.getAmount();
             int remaining = is.getAmount();

--- a/src/main/java/com/entityreborn/chvirtualchests/functions/Player.java
+++ b/src/main/java/com/entityreborn/chvirtualchests/functions/Player.java
@@ -33,6 +33,7 @@ import com.laytonsmith.core.Static;
 import com.laytonsmith.core.constructs.CArray;
 import com.laytonsmith.core.constructs.CNull;
 import com.laytonsmith.core.constructs.CString;
+import com.laytonsmith.core.constructs.CVoid;
 import com.laytonsmith.core.constructs.Construct;
 import com.laytonsmith.core.constructs.Target;
 import com.laytonsmith.core.environments.CommandHelperEnvironment;
@@ -99,14 +100,10 @@ public class Player {
             }
 
             Static.AssertPlayerNonNull(p, t);
-
-            if (VirtualChests.get(id) == null) {
-                return CNull.NULL;
+            if (VirtualChests.get(id) != null) {
+                p.openInventory(VirtualChests.get(id));
             }
-
-            p.openInventory(VirtualChests.get(id));
-
-            return CNull.NULL;
+            return CVoid.VOID;
         }
 
         public String getName() {

--- a/src/main/resources/documentation/Functions.md
+++ b/src/main/resources/documentation/Functions.md
@@ -181,9 +181,14 @@ The original contents are still present if not replaced by the new array.
   Always required when working with a chest.
 [id]: #id
 
+* <a id="id"></a>`type` - String - *The inventory type.*
+
+  This supports most Bukkit Inventory types, most notably BREWING, CHEST, DISPENSER, FURNACE, HOPPER, WORKBENCH, ANVIL, and BEACON.
+[type]: #type
+
 * <a id="size"></a>`size` - Integer - *A capacity for a virtual chest.*
 
-  Must be a multiple of 9. Values greater than 54 will have graphical issues, but otherwise are accepted and functional. Defaults to `54`.
+  Only applies to CHEST inventory type. Must be a multiple of 9. Values greater than 54 will have graphical issues, but otherwise are accepted and functional. Defaults to `54`.
 [size]: #size
 
 * <a id="title"></a>`title` - String - *Displayed title when viewing a virtual chest.*
@@ -193,9 +198,9 @@ The original contents are still present if not replaced by the new array.
 
 * <a id="chestdata"></a>`chestdata` - Associative Array - *An array describing a virtual chest in a form that can be used with `get_value()` and `store_value()`.*
 
-  Contains `id` and optionally `size` and `title`, as well as entries for [`@itemdata`][itemdata] whose keys refer to the slot number. Functions that return this will return null values in empty slots.
+  Contains `id` and optionally `type`, `size` and `title`, as well as entries for [`@itemdata`][itemdata] whose keys refer to the slot number. Functions that return this will return null values in empty slots.
 
-  `size` defaults to `54`, and `title` defaults to `Virtual Chest`.
+  `size` defaults to `54`, `type` defaults to `CHEST`, and `title` defaults to `Virtual Chest`.
 [chestdata]: #chestdata
 
 * <a id="itemid"></a>`itemid` - Integer - *An ID of item.*


### PR DESCRIPTION
eg. create_virtualchest(array('id': 'Example', 'type': 'HOPPER'));

I've been using this on my production server for a bit and it works great.