### PR TITLE
Store inventory title inside VirtualHolder

### DIFF
--- a/src/main/java/com/entityreborn/chvirtualchests/VirtualChests.java
+++ b/src/main/java/com/entityreborn/chvirtualchests/VirtualChests.java
@@ -67,7 +67,7 @@ public class VirtualChests {
     }
 
     public static MCInventory create(String id, MCInventoryType type, String title) {
-        VirtualHolder invHolder = new VirtualHolder(id.toLowerCase().trim());
+        VirtualHolder invHolder = new VirtualHolder(id.toLowerCase().trim(), title);
         InventoryType invType = BukkitMCInventoryType.getConvertor().getConcreteEnum(type);
         return new BukkitMCInventory(Bukkit.createInventory((InventoryHolder)invHolder.getHandle(), invType, title));
     }
@@ -80,7 +80,7 @@ public class VirtualChests {
         int s = size / 9 * 9; // Assert that the size is multiple of 9.
 
         return Static.getServer().createInventory(
-                new VirtualHolder(id.toLowerCase().trim()), s, title);
+                new VirtualHolder(id.toLowerCase().trim(), title), s, title);
     }
 
     public static MCInventory del(String id) {

--- a/src/main/java/com/entityreborn/chvirtualchests/VirtualHolder.java
+++ b/src/main/java/com/entityreborn/chvirtualchests/VirtualHolder.java
@@ -25,6 +25,7 @@ package com.entityreborn.chvirtualchests;
 
 import com.laytonsmith.abstraction.MCInventory;
 import com.laytonsmith.abstraction.MCInventoryHolder;
+import org.bukkit.Nameable;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
 
@@ -34,10 +35,11 @@ import org.bukkit.inventory.InventoryHolder;
  */
 public class VirtualHolder implements MCInventoryHolder {
     // Make bukkit happy.
-    public static class Holder implements InventoryHolder {
+    public static class Holder implements InventoryHolder, Nameable {
 
         String id;
         VirtualHolder parent;
+        String title;
 
         public Holder(String i, VirtualHolder p) {
             id = i;
@@ -55,11 +57,22 @@ public class VirtualHolder implements MCInventoryHolder {
 
             return null;
         }
+
+        @Override
+        public String getCustomName() {
+            return title;
+        }
+
+        @Override
+        public void setCustomName(String s) {
+            title = s;
+        }
     }
         String id;
         Holder holder;
+        String title;
 
-        public VirtualHolder(String i) {
+        public VirtualHolder(String i, String title) {
             id = i;
         }
 
@@ -74,6 +87,7 @@ public class VirtualHolder implements MCInventoryHolder {
         public Object getHandle() {
             if (holder == null) {
                 holder = new Holder(id, this);
+                holder.setCustomName(title);
             }
 
             return holder;


### PR DESCRIPTION
The close and open events are currently failing in 1.14 trying to get the window title.

<details>
<summary>Stacktrace</summary>

```
[12:13:43] [Server thread/ERROR]: Could not pass event InventoryCloseEvent to CommandHelper v3.3.4-SNAPSHOT
java.lang.ClassCastException: com.entityreborn.chvirtualchests.VirtualHolder$Holder cannot be cast to org.bukkit.Nameable
	at com.laytonsmith.abstraction.bukkit.BukkitMCInventory.getTitle(BukkitMCInventory.java:165) ~[?:?]
	at com.entityreborn.chvirtualchests.VirtualChests.toCArray(VirtualChests.java:130) ~[?:?]
	at com.entityreborn.chvirtualchests.events.Events$virtualchest_closed.evaluate(Events.java:182) ~[?:?]
	at com.laytonsmith.core.events.EventUtils.FireListeners(EventUtils.java:306) ~[?:?]
	at com.laytonsmith.core.events.EventUtils.TriggerListener(EventUtils.java:294) ~[?:?]
	at com.entityreborn.chvirtualchests.events.Events.onClose(Events.java:85) ~[?:?]
	at com.destroystokyo.paper.event.executor.asm.generated.GeneratedEventExecutor25.execute(Unknown Source) ~[?:?]
	at org.bukkit.plugin.EventExecutor.lambda$create$1(EventExecutor.java:69) ~[patched_1.14.4.jar:git-Paper-192]
	at co.aikar.timings.TimedEventExecutor.execute(TimedEventExecutor.java:80) ~[patched_1.14.4.jar:git-Paper-192]
	at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:70) ~[patched_1.14.4.jar:git-Paper-192]
	at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:545) ~[patched_1.14.4.jar:git-Paper-192]
	at org.bukkit.craftbukkit.v1_14_R1.event.CraftEventFactory.handleInventoryCloseEvent(CraftEventFactory.java:1344) ~[patched_1.14.4.jar:git-Paper-192]
	at net.minecraft.server.v1_14_R1.PlayerConnection.a(PlayerConnection.java:2089) ~[patched_1.14.4.jar:git-Paper-192]
	at net.minecraft.server.v1_14_R1.PacketPlayInCloseWindow.a(PacketPlayInCloseWindow.java:18) ~[patched_1.14.4.jar:git-Paper-192]
	at net.minecraft.server.v1_14_R1.PacketPlayInCloseWindow.a(PacketPlayInCloseWindow.java:5) ~[patched_1.14.4.jar:git-Paper-192]
	at net.minecraft.server.v1_14_R1.PlayerConnectionUtils.lambda$ensureMainThread$0(PlayerConnectionUtils.java:23) ~[patched_1.14.4.jar:git-Paper-192]
	at net.minecraft.server.v1_14_R1.TickTask.run(SourceFile:18) ~[patched_1.14.4.jar:git-Paper-192]
	at net.minecraft.server.v1_14_R1.IAsyncTaskHandler.executeTask(IAsyncTaskHandler.java:136) ~[patched_1.14.4.jar:git-Paper-192]
	at net.minecraft.server.v1_14_R1.IAsyncTaskHandlerReentrant.executeTask(SourceFile:23) ~[patched_1.14.4.jar:git-Paper-192]
	at net.minecraft.server.v1_14_R1.IAsyncTaskHandler.executeNext(IAsyncTaskHandler.java:109) ~[patched_1.14.4.jar:git-Paper-192]
	at net.minecraft.server.v1_14_R1.MinecraftServer.aX(MinecraftServer.java:1013) ~[patched_1.14.4.jar:git-Paper-192]
	at net.minecraft.server.v1_14_R1.MinecraftServer.executeNext(MinecraftServer.java:1006) ~[patched_1.14.4.jar:git-Paper-192]
	at net.minecraft.server.v1_14_R1.IAsyncTaskHandler.awaitTasks(IAsyncTaskHandler.java:119) ~[patched_1.14.4.jar:git-Paper-192]
	at net.minecraft.server.v1_14_R1.MinecraftServer.sleepForTick(MinecraftServer.java:990) ~[patched_1.14.4.jar:git-Paper-192]
	at net.minecraft.server.v1_14_R1.MinecraftServer.run(MinecraftServer.java:923) ~[patched_1.14.4.jar:git-Paper-192]
	at java.lang.Thread.run(Unknown Source) [?:1.8.0_221]
```
</details>

`getTitle()` was [changed](https://github.com/EngineHub/CommandHelper/commit/911deb102204c86d6c36811d23b09678cec57d49#diff-87969b731da6eb9cf82b63c7d4cda85eL163) to use the title from the inventory holder  rather than the inventory directly, which is expected to be a `Nameable`.

This makes VirtualHolder nameable, and sets the name to the inventory title.